### PR TITLE
Fix timeout when promiseValue is null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ function sp (func, options = {}) {
     const waitUntil = new Date(new Date().getTime() + timeouts)
     while ((waitUntil > new Date()) && typeof promiseError === 'undefined') {
       require('deasync').sleep(100)
-      if (promiseValue) {
+      if (promiseValue !== undefined) {
         return promiseValue
       }
     }


### PR DESCRIPTION
My promise ended and she sent "null".
In this case, my asynchronous function is terminated.
Despite this, the timeout counter continues to increment.
To solve the problem, the "promiseValue" must be different from undefined.